### PR TITLE
Fix ground grid and generate infinite

### DIFF
--- a/utils/Grid.ts
+++ b/utils/Grid.ts
@@ -88,14 +88,15 @@ export function createKujialeGrid(opts: GridOptions = {}) {
       // 将线宽体现在阈值里：deriv * (thicknessPx)
       vec2 w = deriv * thicknessPx * 0.5;
       vec2 a = smoothstep(w, vec2(0.0), d);      // a 越大表示越靠近线
-      return 1.0 - min(min(a.x, a.y), 1.0);      // 线区域 ~1，非线区域 ~0
+      return max(a.x, a.y);                      // 返回线的透明度，修正原来的反向计算
     }
 
     // 坐标轴（x=0 或 z=0）加粗，高优先级覆盖
     float axisLine(vec2 worldXZ, float thicknessPx){
       // 使用世界坐标直接做 0 线，仍然用 fwidth 保证屏幕一致线宽
-      float ax = 1.0 - smoothstep(fwidth(worldXZ.x) * thicknessPx * 0.5, 0.0, abs(worldXZ.x));
-      float az = 1.0 - smoothstep(fwidth(worldXZ.y) * thicknessPx * 0.5, 0.0, abs(worldXZ.y));
+      float w = thicknessPx * 0.5;
+      float ax = smoothstep(fwidth(worldXZ.x) * w, 0.0, abs(worldXZ.x));
+      float az = smoothstep(fwidth(worldXZ.y) * w, 0.0, abs(worldXZ.y));
       return max(ax, az);
     }
 
@@ -108,9 +109,6 @@ export function createKujialeGrid(opts: GridOptions = {}) {
       float majorMask = gridLine(p, majorSpacing, uMajorPx);
       float minorMask = gridLine(p, uMinor,       uMinorPx);
 
-      // 主线覆盖在次线上
-      minorMask *= (1.0 - majorMask);
-
       // 坐标轴覆盖在所有线上
       float axisMask = axisLine(p, uAxisPx);
 
@@ -118,15 +116,17 @@ export function createKujialeGrid(opts: GridOptions = {}) {
       vec3 col = vec3(0.0);
       float alpha = 0.0;
 
-      // 次网格
-      col   = mix(col, uMinorColor, minorMask);
-      alpha = max(alpha, minorMask);
+      // 次网格（只在没有主网格和坐标轴的地方显示）
+      float minorContrib = minorMask * (1.0 - majorMask) * (1.0 - axisMask);
+      col   = mix(col, uMinorColor, minorContrib);
+      alpha = max(alpha, minorContrib);
 
-      // 主网格
-      col   = mix(col, uMajorColor, majorMask);
-      alpha = max(alpha, majorMask);
+      // 主网格（只在没有坐标轴的地方显示）
+      float majorContrib = majorMask * (1.0 - axisMask);
+      col   = mix(col, uMajorColor, majorContrib);
+      alpha = max(alpha, majorContrib);
 
-      // 坐标轴
+      // 坐标轴（最高优先级）
       col   = mix(col, uAxisColor, axisMask);
       alpha = max(alpha, axisMask);
 


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix the ground grid effect to correctly display an infinite grid with proper line blending and transparency.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous implementation suffered from incorrect transparency calculations in `gridLine` and `axisLine` functions, which caused lines to render improperly. Additionally, the blending logic for minor, major, and axis lines did not correctly prioritize and combine the different grid components, leading to visual errors. This PR addresses these issues by correcting the transparency calculations and implementing a robust blending system that ensures higher-priority lines (like axes) correctly overlay lower-priority lines, resulting in a visually accurate and infinite ground grid.

---
<a href="https://cursor.com/background-agent?bcId=bc-6685bdd9-ebf8-4e21-a992-e79d0c7249ae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6685bdd9-ebf8-4e21-a992-e79d0c7249ae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

